### PR TITLE
Localeエラー修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,8 +9,8 @@ Bundler.require(*Rails.groups)
 module FreemarketSample0609b
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
-    config.i18n.default_locale = :ja
+    # config.load_defaults 5.2
+    # config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,2 @@
+I18n.config.available_locales = :ja
+I18n.default_locale = :ja


### PR DESCRIPTION
# WHAT
本番環境のエラー修正
本番環境で商品出品画面にアクセス時、以下エラーが発生
```
I18n::InvalidLocale (:ja is not a valid locale):
i18n (1.6.0) lib/i18n.rb:326:in `enforce_available_locales!'
```

Qiita記事を参考に設定を修正
https://qiita.com/foloinfo/items/f56867a630ecf9e90fdd

# WHY
商品出品機能実装のため

# エラー画面
[![Image from Gyazo](https://i.gyazo.com/f6d6854db2e3851285def49058a8f4c9.png)](https://gyazo.com/f6d6854db2e3851285def49058a8f4c9)