### PR TITLE
load_defaults有効化

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module FreemarketSample0609b
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    # config.load_defaults 5.2
+    config.load_defaults 5.2
     # config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
# WHAT
商品出品画面エラー解消
 - レイアウトの崩れ修正
 - jQueryが動かない

config/application.rbの
config.load_defaults 5.2
をコメントアウトしたことが原因

参考記事：
https://y-yagi.tumblr.com/post/160114728555/rails-51%E3%81%A7%E8%BF%BD%E5%8A%A0%E3%81%95%E3%82%8C%E3%81%9Fconfig%E3%81%BE%E3%81%A8%E3%82%81

関連：
#19 
#20 

# WHY
商品出品機能実装のため