### PR TITLE
商品説明：最大文字数修正

### DIFF
--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -14,7 +14,7 @@
       </div>
       <div class='product_form__description'>
         <p class='column_title'>商品の説明 <span class='required'>必須</span></p>
-        <%= f.text_area :description, placeholder: '商品の説明（必須 1,000文字以内）', maxlength: '40' %>
+        <%= f.text_area :description, placeholder: '商品の説明（必須 1,000文字以内）', maxlength: '1000' %>
       </div>
     </div>
     <div class='product_form__detail'>


### PR DESCRIPTION
# WHAT
商品出品画面
商品説明の最大文字数修正
40文字から1000文字へ

# WHY
商品出品機能実装のため