### PR TITLE
ImageUploader関連修正

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,4 @@
 class Image < ApplicationRecord
   belongs_to :product
+  mount_uploader :image, ImageUploader
 end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @product, local: true do |f| %>
+<%= form_with model: @product, local: true, multipart: true do |f| %>
   <div class='product_form'>
     <p class='title'>商品の情報を入力</p>
     <div class='product_form__image'>


### PR DESCRIPTION
# WHAT
AWSに画像がアップロードされないバグの修正
 - Imageモデルにmount_uploader追加（元々の記載もれ）
 - form_withにファイル操作用のプロパティ multipart: true を追加

参考：
https://www.rubydoc.info/github/jnicklas/carrierwave/CarrierWave%2FMount:mount_uploader
https://workabroad.jp/tech/1118

# WHY
商品出品機能実装のため