### PR TITLE
商品購入画面

### DIFF
--- a/app/assets/javascripts/purchase_edit.js
+++ b/app/assets/javascripts/purchase_edit.js
@@ -1,0 +1,4 @@
+$(function() {
+  $('#purchase_payment').val($('#payment').text());
+  $('#payment').text("¥ " + $('#payment').text());
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @import "modules/progress";
 @import "users/sign-up";
 @import "products";
+@import "purchases";

--- a/app/assets/stylesheets/purchases.scss
+++ b/app/assets/stylesheets/purchases.scss
@@ -1,3 +1,78 @@
-// Place all the styles related to the Purchases controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+.logo {
+  width: 300px;
+  margin: 0 auto;
+  text-align : center;
+}
+
+.title {
+  height: 30px;
+  font-weight: bold;
+}
+
+.purchase_information {
+  width:300px;
+  margin: 0 auto;
+  text-align : center;
+
+  &__image {
+    border-top: 1px solid rgb(200, 200, 200);
+    padding: 5px 0px 5px 0px;
+  }
+
+  &__name {
+    padding: 5px 0px 5px 0px;
+  }
+
+  &__price {
+    padding: 5px 0px 5px 0px;
+  }
+
+  &__option {
+    font-size: 5px;
+    color: gray;
+  }
+
+  &__point {
+    margin: 5px 0px 5px 0px;
+    padding: 10px 0px 10px 0px;
+    width: 270px;
+    border: none;
+    background-color: rgb(200, 200, 200);
+    cursor: pointer;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  &__payment {
+    padding: 5px 0px 5px 0px;
+  }
+
+  #payment_title {
+    display: inline-block;
+    margin: 0px 150px 0px 0px;
+  }
+
+  #payment {
+    display: inline-block;
+  }
+}
+
+.purchase_form {
+  width:300px;
+  margin: 0 auto;
+  text-align : center;
+
+  &__submit {
+    padding: 10px 0px 10px 0px;
+    width: 270px;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: rgb(200, 200, 200);
+    .submit_button {
+      width: 270px;
+      border: none;
+      background-color: rgb(200, 200, 200);
+      cursor: pointer;
+    }
+  }
+}

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,5 +1,5 @@
 class PurchasesController < ApplicationController
-  before_action :set_purchase, only: [:update]
+  before_action :set_purchase, only: [:edit, :update]
 
   require 'payjp'
 
@@ -53,5 +53,7 @@ class PurchasesController < ApplicationController
   def set_purchase
     # データ取得
     @purchase = Purchase.find(params[:id])
+    @derivery = current_user.user_deriverys.first
+    @image = @purchase.product.images.first
   end
 end

--- a/app/views/products/_form_new.html.haml
+++ b/app/views/products/_form_new.html.haml
@@ -47,7 +47,7 @@
             配送料の負担
             %span.required 必須
           = f.collection_select :delivery_fee_pay_id, DeliveryFeePay.all, :id, :delivery_fee_pay ,include_blank: '---'
-        .product_form__delivery_way{:hidden => ""}
+        .product_form__delivery_way{hidden: ""}
           %p.column_title
             配送の方法
             %span.required 必須
@@ -74,14 +74,14 @@
           = f.number_field :price
         .product_form__fee
           %p.column_title 販売手数料（10%）
-          %input#product_fee{:disabled => "disabled", :placeholder => "販売手数料（10%）"}/
+          %input#product_fee{disabled: "disabled", placeholder: "販売手数料（10%）"}/
         .product_form__profit
           %p.column_title 販売利益
-          %input#product_profit{:disabled => "disabled"}/
-    .product_form__hidden{:hidden => ""}
-      .product_form__product_status{:hidden => ""}
+          %input#product_profit{disabled: "disabled"}/
+    .product_form__hidden{hidden: ""}
+      .product_form__product_status{hidden: ""}
         = f.text_field :product_status_id, value: 1
-      .product_form__purchase{:hidden => ""}
+      .product_form__purchase{hidden: ""}
         = f.fields_for :purchase do |purchase|
           = purchase.text_field :seller_id, value: current_user.id
     .product_form__submit

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,3 +1,3 @@
 .logo
   = image_tag 'logo.png', alt: 'mercari', width:'134', height:'36'
-= render 'form', product: @product
+= render 'form_new', product: @product

--- a/app/views/purchases/_form_edit.html.haml
+++ b/app/views/purchases/_form_edit.html.haml
@@ -1,0 +1,9 @@
+= form_with model: @purchase, local: true, multipart: true do |f|
+  .purchase_form
+    .purchase_form__hidden{hidden: ""}
+      .purchase_form__payment
+        = f.text_field :payment
+      .purchase_form__buyer
+        = f.text_field :buyer_id, value: current_user.id
+    .purchase_form__submit
+      = f.submit '購入する', class:'submit_button'

--- a/app/views/purchases/edit.html.haml
+++ b/app/views/purchases/edit.html.haml
@@ -18,6 +18,7 @@
     %p#payment
       = @purchase.product.price
 = render 'form_edit', purchase: @purchase
+-# TODO ユーザ新規登録機能作成時に対応
 -# .user_information
 -#   .user_information__address
 -#     %p

--- a/app/views/purchases/edit.html.haml
+++ b/app/views/purchases/edit.html.haml
@@ -1,0 +1,33 @@
+.logo
+  = image_tag 'logo.png', alt: 'mercari', width:'134', height:'36'
+.purchase_information
+  %p.title 購入内容の確認
+  .purchase_information__image
+    = image_tag @image.image.to_s, size: "150x150", alt: "product_image"
+  .purchase_information__name
+    %p
+      = @purchase.product.name
+  .purchase_information__price
+    %p#price
+      = '¥ ' + @purchase.product.price.to_s
+      %span.purchase_information__option 送料込み
+  .purchase_information__point
+    %p ポイントはありません
+  .purchase_information__payment
+    %p#payment_title 支払い金額
+    %p#payment
+      = @purchase.product.price
+= render 'form_edit', purchase: @purchase
+-# .user_information
+-#   .user_information__address
+-#     %p
+-#       = @derivery.zip_code
+-#     %p
+-#       = @derivery.city
+-#     %p
+-#       = @derivery.street
+-#     %p
+-#       = @derivery.building_name
+-#   .user_information__name
+-#     %p
+-#       = current_user.family_name + ' ' + current_user.first_name


### PR DESCRIPTION
# WHAT
商品購入画面の実装
 - メルカリの元画面から一部の記述を除外
 - 初期表示のため、コントローラを一部修正
 - わかりやすくするため、Product#newの_form.html.hamlを名称変更
 - Haml変換時のロケット記法をハッシュ記法に変更
 - 商品購入機能（Purchases#update）のフォームは値変更不要のため、hidden属性に
 - ページ読込時にjQueryでフォームの値を設定
 - Payjpは別ブランチで実装
 - 配送先住所は別ブランチでユーザ新規登録機能を作成中のため、別途マージ

Payjpの画面を実装していないため、購入ボタンを押すとエラーになります

# WHY
商品購入画面実装のため

# DISPLAY
[![Image from Gyazo](https://i.gyazo.com/248d598b77b84e4ddcf536134bf249b5.png)](https://gyazo.com/248d598b77b84e4ddcf536134bf249b5)