### PR TITLE
クレジットカード決済機能実装

### DIFF
--- a/app/assets/stylesheets/purchases.scss
+++ b/app/assets/stylesheets/purchases.scss
@@ -61,18 +61,5 @@
   width:300px;
   margin: 0 auto;
   text-align : center;
-
-  &__submit {
-    padding: 10px 0px 10px 0px;
-    width: 270px;
-    margin-left: auto;
-    margin-right: auto;
-    background-color: rgb(200, 200, 200);
-    .submit_button {
-      width: 270px;
-      border: none;
-      background-color: rgb(200, 200, 200);
-      cursor: pointer;
-    }
-  }
+  padding: 10px 0px 10px 0px;
 }

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -14,7 +14,7 @@ class PurchasesController < ApplicationController
       @purchase.product.save
 
       # Payjp
-      create_charge(create_token, @purchase.payment)
+      create_charge(@purchase.payment)
 
       # トップページへリダイレクト
       redirect_to root_path
@@ -28,24 +28,10 @@ class PurchasesController < ApplicationController
     params.require(:purchase).permit(:payment, :buyer_id)
   end
 
-  def create_token
-    # Payjpトークン作成
-    # VISAテストカードを使用
-    token = Payjp::Token.create(
-      card: {
-        number:    '4242424242424242',
-        cvc:       '123',
-        exp_year:  '2020',
-        exp_month: '2',
-      }
-    )
-    return token[:id]
-  end
-
-  def create_charge(token, amount)
+  def create_charge(amount)
     Payjp::Charge.create(
       amount:   amount,
-      card:     token,
+      card:     params['payjp-token'],
       currency: 'jpy'
     )
   end

--- a/app/views/purchases/_form_edit.html.haml
+++ b/app/views/purchases/_form_edit.html.haml
@@ -5,5 +5,4 @@
         = f.text_field :payment
       .purchase_form__buyer
         = f.text_field :buyer_id, value: current_user.id
-    .purchase_form__submit
-      = f.submit '購入する', class:'submit_button'
+    %script.payjp-button{src: "https://checkout.pay.jp/", "data-key" => "pk_test_74ead5292fa5eabf7b238ed4"}


### PR DESCRIPTION
# WHAT
Payjpによるクレジットカード決済機能の実装
 - PayjpのチェックアウトAPIを使った決済を導入
 - Purchasesコントローラのcreate_tokenメソッドを削除し、create_chargeメソッドを一部修正
 - "購入するボタン"をPayjp仕様の"カードで支払う"ボタンに変更
 - Payjpはテストモードで運用、カードはテストカードを使用

# WHY
商品購入機能実装のため

# DISPLAY
[![Image from Gyazo](https://i.gyazo.com/8ae3f8630cd444f292dc4c33b57efb57.png)](https://gyazo.com/8ae3f8630cd444f292dc4c33b57efb57)

[![Image from Gyazo](https://i.gyazo.com/ebd4c004e7b5ecce35cdda7ca576a476.png)](https://gyazo.com/ebd4c004e7b5ecce35cdda7ca576a476)