### PR TITLE
商品詳細見た目のみ作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,4 @@
 @import "users/sign-up";
 @import "products";
 @import "purchases";
+@import "product-detail"

--- a/app/assets/stylesheets/product-detail.scss
+++ b/app/assets/stylesheets/product-detail.scss
@@ -1,0 +1,257 @@
+.default-container {
+  .product-detail{
+    background: #fff;
+    margin: 40px auto 0;
+    padding: 24px 16px 55px 16px;
+    width: 700px;
+    .product-name {
+      font-size: 24px;
+      text-align: center;
+      word-wrap: break-word;
+      line-height: 1.4;
+    }
+    .product-info {
+      margin: 16px 0 0;
+      display: flex;
+      &__photo {
+        position: relative;
+        min-width: 280px;
+        max-width: 360px;
+        min-height: 280px;
+        margin: 0 auto;
+        background: #fafafa;
+        &--main {
+          width: 100%;
+          text-align: center;
+          position: relative;
+          overflow: hidden;
+          .pengin {
+
+          }
+        }
+      }
+      .detail-table {
+        width: 100%;
+        max-width: 360px;
+        margin: 8px auto 0;
+        border-collapse: collapse;
+        border: 1px solid #f5f5f5;
+        th {
+          width: 39%;
+          text-align: left;
+          font-weight: 400;
+          background: #fafafa;
+        }
+        td {
+          width: 61%;
+          background: #fff;
+        }
+        th td {
+          border-collapse: collapse;
+          border: 1px solid #f5f5f5;
+          padding: 16px 8px;
+        }
+        .evaluation {
+          display: inline-flex;
+          font-size: 16px;
+          vertical-align: middle;
+          width: 100%;
+          justify-content: space-around;
+          .good {
+            color: #ef5185;
+          }
+          .nomal {
+            color: #fba933;
+          }
+          .bad {
+            color: #6ab5d8;
+          }
+        }
+      }
+    }
+    .product-price {
+      margin: 24px 0 0;
+      &__money {
+        margin: 0 8px 0 0;
+        font-size: 32px;
+      }
+      &__tax {
+        font-size: 10px;
+      }
+      &__postage {
+        display: inline-block;
+        font-size: 16px;
+      }
+    }
+    .product-buy-button {
+      display: block;
+      height: 56px;
+      margin: 16px 0 0;
+      background: #ea352d;
+      color: #fff;
+      line-height: 56px;
+      text-align: center;
+      font-weight: 600;
+      font-size: 24px;
+      -webkit-transition: all ease-out .3s;
+      transition: all ease-out .3s;
+    }
+    .product-description {
+      padding: 24px 0 0;
+      line-height: 1.5;
+    }
+    .product-button-container {
+      width: 100%;
+      margin: 16px 0 0;
+      font-size: 0;
+      display: inline-block;
+      span {
+        display: inline-block;
+        margin: 1px 0 0 8px;
+        font-size: 12px;
+        vertical-align: middle;
+      }
+      &--left-buttons {
+        display: inline-block;
+        float: left;
+        .product-button {
+          display: inline-block;
+          padding: 8px 16px;
+          border-radius: 40px;
+          -webkit-transition: all ease-out .3s;
+          transition: all ease-out .3s;
+        }
+        .like-button {
+          color: #333;
+          border: 1px solid #f5f5f5;
+          background: #f5f5f5;
+        }
+        .report-button {
+          margin: 0 0 0 8px;
+          color: #333;
+          background: #f5f5f5;
+          display: inline-block;
+          margin: 1px 0 0 8px;
+          font-size: 12px;
+          vertical-align: middle;
+        }
+      }
+      &--right-button {
+        float: right;
+        display: inline-block;
+        color: #0099e8;
+        text-decoration: none;
+        display: inline-block;
+        margin: 1px 0 0 8px;
+        font-size: 12px;
+        vertical-align: middle;
+      }
+    }
+  }
+  .product-comment {
+    width: 734px;
+    margin: 8px auto;
+    &__container {
+      padding: 24px 7.5%;
+      background: #fff;
+      &--form {
+
+      }
+    }
+  }
+
+  .nav-product-link-next {
+    margin: 24px auto 0;
+    width: 734px;
+    .backnext {
+      list-style: none;
+      margin: 24px 0;
+      li {
+        position: relative;
+        width: 43%;
+        word-wrap: break-word;
+      }
+      .back {
+        float: left;
+        padding: 0 0 0 14px;
+        a {
+          float: left;
+        }
+      }
+      .next {
+        float: right;
+        width: 43%;
+        word-wrap: break-word;
+        a {
+          float: right;
+        }
+      }
+    }
+  }
+
+  .social-media-box {
+    margin: 24px auto 0;
+    background: #fff;
+    padding: 16px 0 8px;
+    width: 734px;
+    .social-media-links {
+      display: inline;
+      li {
+        display: inline-block;
+        margin: 0 8px 8px 0;
+        vertical-align: middle;
+        text-align: center;
+        font-size: 30px;
+      }
+      .fa-facebook-square {
+        color:#385185;
+        background: #fff;
+      }
+      .fa-twitter-square {
+        color: #0099e8;
+        background: #fff;
+      }
+      .fa-line {
+        color: #00c137;
+        background: #fff;
+      }
+      .fa-pinterest-square {
+        color: #aa262a;
+        background: #fff;
+      }
+    }
+  }
+  other-products{
+    .user-products {
+      h2 {
+        font-size: 18px;
+        margin: 24px 4% 8px;
+        line-height: 1.4;
+        a {
+        color: #0099e8;
+        text-decoration: none;
+        }
+      }
+      &__photos{
+        .photo-box {
+
+        }
+      }
+    }
+
+    .relation-products {
+      h3 {
+        font-size: 18px;
+        margin: 24px 4% 8px;
+        line-height: 1.4;
+        a {
+          color: #0099e8;
+          text-decoration: none;
+        }
+      }
+      &__photos{
+
+      }
+    }
+  }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,14 +3,14 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit, :create, :update]
 
   def index
-   @ladies_products = Product.where(product_status_id: 1).get_ladies.recent
-   @mens_products = Product.where(product_status_id: 1).get_mens.recent
-   @kids_products = Product.where(product_status_id: 1).get_kids.recent
-   @cosme_products = Product.where(product_status_id: 1).recent
-   @chanel_products = Product.where(brand_id: 1, product_status_id: 1).recent
-   @Vuitton_products = Product.where(brand_id: 2, product_status_id: 1).recent
-   @Supreme_products = Product.where(brand_id: 3, product_status_id: 1).recent
-   @nike_products = Product.where(brand_id: 4, product_status_id: 1).recent
+    @ladies_products = Product.where(product_status_id: 1).get_ladies.recent
+    @mens_products = Product.where(product_status_id: 1).get_mens.recent
+    @kids_products = Product.where(product_status_id: 1).get_kids.recent
+    @cosme_products = Product.where(product_status_id: 1).recent
+    @chanel_products = Product.where(brand_id: 1, product_status_id: 1).recent
+    @Vuitton_products = Product.where(brand_id: 2, product_status_id: 1).recent
+    @Supreme_products = Product.where(brand_id: 3, product_status_id: 1).recent
+    @nike_products = Product.where(brand_id: 4, product_status_id: 1).recent
   end
 
   def new
@@ -29,6 +29,17 @@ class ProductsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    #@product = Product.find_by(id: params[:id])
+    #@category = @product.category.includes(:products)
+    #@brand = @product.brand.includes(:products)
+    #@condition = @product.condition.includes(:products)
+    #@delivery_fee_pay = @product.delivery_fee_pay.includes(:products)
+    #@delivery_way = @product.delivery_off_way.includes(:products)
+    #@delivery_off_area = @product.delivery_off_area.includes(:products)
+    #@delivery_off_day = @product.delivery_off_day.includes(:products)
   end
 
   def edit

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,0 +1,120 @@
+.default-container
+  / ヘッダー↓
+  = render partial: "/partial/header"
+
+  /商品詳細↓
+  .product-detail
+    %h1.product-name 商品名
+    .product-info.clearfix
+      .product-info__photo
+        .product-info__photo--main
+          = image_tag 'https://bellard.org/bpg/2small.png', class: 'pengin'
+      %table.detail-table
+        %tr
+          %th.table-user-name 出品者
+          %td
+            .user_name otake
+            .evaluation
+              .good
+                .fas.fa-smile-beam
+                .good_num 1
+              .nomal
+                .fas.fa-surprise
+                .nomal_num 1
+              .bad
+                .fas.fa-sad-tear
+                .bad_num 1
+        %tr
+          %th.table-content カテゴリー
+          %td a
+        %tr
+          %th.table-content ブランド
+          %td a
+        %tr
+          %th.table-content 商品のサイズ
+          %td a
+        %tr
+          %th.table-content 商品の状態
+          %td a
+        %tr
+          %th.table-content 配送料の負担
+          %td a
+        %tr
+          %th.table-content 配送の方法
+          %td a
+        %tr
+          %th.table-content 配送元地域
+          %td a
+        %tr
+          %th.table-content 配送日の目安
+          %td a
+    .product-price
+      %span.product-price__money ¥お金
+      %span.product-price__tax (税込)
+      %span.product-price__postage 送料込み
+    .product-buy-button
+      = link_to "購入画面に進む", ""
+    .product-description 商品の説明
+    .product-button-container.clearfix
+      .product-button-container--left-buttons
+        .like-button.product-button
+          %i.far.fa-heart
+          %span いいね！
+          %span.like-num 3
+        .report-button.product-button
+          %i.fas.fa-flag
+          %span 不適切な商品の報告
+      .product-button-container--right-button
+        %i.fas.fa-lock
+        = link_to "あんしん・あんぜんへの取り組み", "https://www.mercari.com/jp/safe/description/"
+  /コメント↓
+  -#  .product-comment
+  -#    .product-comment__container
+  -#      .product-comment__container--detail
+  -#        %ul.comments
+  -#          %li.comment hahaha
+  -#          %li.comment rarara
+  -#      .product-comment__container--form
+  -#        %p.tyuuigaki 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+  -#        = form_for @comment do |f|
+  -#          = f.text_field :name
+  -#        .comentsurubutton
+
+  /前後ページ↓
+  .nav-product-link-next.clearfix
+    %ul.backnext.clearfix
+      %li.back
+        = link_to "前のやつ", "https://item.mercari.com/jp/m88594702450/"
+      %li.next
+        = link_to "次のやつ", "https://item.mercari.com/jp/m88594702450/"
+
+  /SNS関連↓
+  .social-media-box
+    %ul.social-media-links
+      %li.share-btn
+        = link_to "https://www.facebook.com/login.php?skip_api_login=1&api_key=966242223397117&signed_next=1&next=https%3A%2F%2Fwww.facebook.com%2Fshare.php%3Fu%3Dhttps%253A%252F%252Fitem.mercari.com%252Fjp%252Fm24765294080%252F&cancel_url=https%3A%2F%2Fwww.facebook.com%2Fdialog%2Fclose_window%2F%3Fapp_id%3D966242223397117%26connect%3D0%23_%3D_&display=popup&locale=ja_JP" do
+          %i.fab.fa-facebook-square
+      %li.share-btn
+        = link_to "https://twitter.com/intent/tweet?text=SK-II%20%E3%83%95%E3%82%A7%E3%82%A4%E3%82%B7%E3%83%A3%E3%83%AB%E2%80%A6%20%28%C2%A5%208%2C800%29%20https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm24765294080%2F%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%E3%80%8C%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%E3%80%8D%E3%81%A7%E8%B2%A9%E5%A3%B2%E4%B8%AD%E2%99%AA%20%23%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%40mercari_jp%E3%81%95%E3%82%93%E3%81%8B%E3%82%89&url=&original_referer=" do
+          %i.fab.fa-twitter-square
+      %li.share-btn
+        = link_to "https://access.line.me/oauth2/v2.1/login?returnUri=%2Foauth2%2Fv2.1%2Fauthorize%2Fconsent%3Fscope%3Dopenid%2Bprofile%2Bfriends%2Bgroups%2Btimeline.post%2Bmessage.write%26response_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Fsocial-plugins.line.me%252Flineit%252FloginCallback%253FreturnUrl%253Dhttps%25253A%25252F%25252Fsocial-plugins.line.me%25252Flineit%25252Fshare%25253Furl%25253D%252526text%25253DSK-II%25252520%252525E3%25252583%25252595%252525E3%25252582%252525A7%252525E3%25252582%252525A4%252525E3%25252582%252525B7%252525E3%25252583%252525A3%252525E3%25252583%252525AB%252525E3%25252583%25252588%252525E3%25252583%252525AA%252525E3%25252583%252525BC%252525E3%25252583%25252588%252525E3%25252583%252525A1%252525E3%25252583%252525B3%252525E3%25252583%25252588%252525E3%25252583%2525259E%252525E3%25252582%252525B9%252525E3%25252582%252525AF%252525E3%25252580%25252580sk2%2525252010%252525E6%2525259E%2525259A%25252520%2525257C%25252520%252525E3%25252583%252525A1%252525E3%25252583%252525AB%252525E3%25252582%252525AB%252525E3%25252583%252525AA%25252520%252525E3%25252582%252525B9%252525E3%25252583%2525259E%252525E3%25252583%2525259B%252525E3%25252581%252525A7%252525E3%25252581%2525258B%252525E3%25252582%25252593%252525E3%25252581%2525259F%252525E3%25252582%25252593%25252520%252525E3%25252583%25252595%252525E3%25252583%252525AA%252525E3%25252583%2525259E%252525E3%25252582%252525A2%252525E3%25252583%25252597%252525E3%25252583%252525AA%2525250D%2525250Ahttps%25253A%25252F%25252Fitem.mercari.com%25252Fjp%25252Fm24765294080%25252F%252526from%25253Dline_scheme%26state%3D6a46b4bc361c2a2666306b73e6175c%26client_id%3D1446101138&loginChannelId=1446101138&loginState=6B8K412P4K12Uar4HrvXCY#/" do
+          %i.fab.fa-line
+      %li.share-btn
+        = link_to "https://www.pinterest.jp/login/?next=/pin/create/button/%3Furl%3Dhttps%253A%252F%252Fitem.mercari.com%252Fjp%252Fm24765294080%252F%26media%3Dhttps%253A%252F%252Fstatic.mercdn.net%252Fitem%252Fdetail%252Forig%252Fphotos%252Fm24765294080_1.jpg%253F1566341567%26description%3D%25E3%2583%25A1%25E3%2583%25AB%25E3%2582%25AB%25E3%2583%25AA%25E5%2595%2586%25E5%2593%2581%253A%2520SK-II%2520%25E3%2583%2595%25E3%2582%25A7%25E3%2582%25A4%25E3%2582%25B7%25E3%2583%25A3%25E3%2583%25AB%25E3%2583%2588%25E3%2583%25AA%25E3%2583%25BC%25E3%2583%2588%25E3%2583%25A1%25E3%2583%25B3%25E3%2583%2588%25E3%2583%259E%25E3%2582%25B9%25E3%2582%25AF%25E3%2580%2580sk2%252010%25E6%259E%259A%2520%2523%25E3%2583%25A1%25E3%2583%25AB%25E3%2582%25AB%25E3%2583%25AA" do
+          %i.fab.fa-pinterest-square
+  .other-products
+    /その他商品↓
+    %section.user-products
+      %h2
+        = link_to 'userさんのその他の出品', ''
+      .user-products__photos.clearfix
+        .photo-box
+    /関連商品↓
+    %section.relation-products
+      %h3
+        = link_to '関連のその他の出品', ''
+      .relation-products__photos.clearfix
+
+  /フッター↓
+  = render partial: "/partial/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:show, :new, :create, :edit, :update]
   root 'products#index'
-  resources :products, only: [:index, :new, :create, :edit, :update], shallow: true do
+  resources :products, only: [:index, :new, :create, :edit, :update, :show], shallow: true do
     resources :images, only: [:new, :create, :edit, :update]
     resources :purchases, only: [:new, :create, :edit, :update]
   end

--- a/db/migrate/20190821234055_create_comments.rb
+++ b/db/migrate/20190821234055_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comments do |t|
+      t.integer :user_id
+      t.integer :product_id
+      t.text :comment
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_21_081724) do
+ActiveRecord::Schema.define(version: 2019_08_21_234055) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "brand", null: false
@@ -28,6 +28,14 @@ ActiveRecord::Schema.define(version: 2019_07_21_081724) do
     t.bigint "parent_id"
     t.bigint "size_type_id"
     t.index ["parent_id"], name: "index_categories_on_parent_id"
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "product_id"
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
WHAT
商品詳細ページ見た目のみ作成
https://gyazo.com/99f93eee544f3febcabea2308f261d52

WHY
必須機能のため

※
一度コメント機能実装しようとしたためテーブル作ってあります
現在ローカル環境でユーザー登録およびログインができないため、見た目のみとなります
バックエンドはコントローラーにコメントアウトしてます。ユーザー登録出来次第、実装します
画像ファイルやカテゴリなどのリンクも同様に未実装です