### PR TITLE
商品名検索機能実装

### DIFF
--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -7,7 +7,7 @@
     width: 71%;
     margin: 0 auto;
     padding: 8px 0 0;
-    .melogo{
+    .mercari-logo{
       float: left;
   }
 }
@@ -21,7 +21,7 @@
   .input-default{
     width: 100%;
     height: 36px;
-    padding: 9px 32px 9px 8px;
+    padding: 9px 45px 9px 8px;
     background: #fafafa;
     border-radius: 4px;
     border: 1px solid #ccc;
@@ -34,13 +34,12 @@
     top: 0;
     right: 0;
     width: 35px;
-    line-height: 35px;
+    line-height: 30px;
     cursor: pointer;
-    text-align: center;
-    height: 20px;
+    height: 30px;
     background: #fafafa;
-    margin-top: 1px;
-    margin-right: 5px;
+    margin: 3px 5px 3px 0px;
+    border: none;
   }
   }
 }
@@ -72,6 +71,7 @@
   }
   li{
     float: left;
+    margin-right: 20px;
   }
 }
 

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -38,9 +38,8 @@
       display: inline-block;
       float: left;
       width: 48%;
-      margin: 0 0 4% 4%;
       background: #FFF;
-      margin: 0 0 0 20px;
+      margin: 0 0 20px 20px;
       width: 213px;
       display: block;
       color: #333;

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -150,3 +150,15 @@ select {
     }
   }
 }
+
+.search_result {
+  width: auto;
+  margin: 0 auto;
+  padding: 20px 0px 0px 0px;
+  &__result {
+    margin: 0 auto;
+    font-size: 16px;
+    font-weight: 400;
+    padding: 0px 0px 10px 0px;
+  }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -41,6 +41,10 @@ class ProductsController < ApplicationController
     end
   end
 
+  def search
+    @products = Product.search(params[:product_name])
+  end
+
   private
 
   def product_params

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -28,10 +28,8 @@ class Product < ApplicationRecord
   validates :delivery_off_day, presence: true
   validates :category, presence: true
 
-
   scope :recent, -> { order(created_at: :desc).limit(4) }
   scope :get_category_products, -> (category_id) { where(category_id: category_id)}
-
 
   def self.get_ladies
     categories = Category.where(parent_id: 14..32)
@@ -46,5 +44,10 @@ class Product < ApplicationRecord
   def self.get_kids
     categories = Category.where(parent_id: 47..61)
     kids = get_category_products(categories)
+  end
+
+  def self.search(product_name)
+    return Product.all unless product_name
+    Product.where(['name LIKE ?', "%#{product_name}%"])
   end
 end

--- a/app/views/partial/_header.html.haml
+++ b/app/views/partial/_header.html.haml
@@ -2,10 +2,9 @@
   .header-innner
     .clearfix
       .mercari-logo
-        = image_tag 'logo.png', alt: 'mercari', width:'134', height:'36'
-      %form.header-form{:action => ""}
-        %input.input-default{:name => "keyword", :placeholder => "キーワードから探す", :type => "search", :value => ""}/
-        = fa_icon 'search', class: "icon-search"
+        = link_to root_path do
+          = image_tag 'logo.png', alt: 'mercari', width:'134', height:'36'
+      = render partial: "/partial/search"
     .header-nav-bar.clearfix
       %nav.content-left
         %ul.header-nav-list

--- a/app/views/partial/_search.html.haml
+++ b/app/views/partial/_search.html.haml
@@ -1,0 +1,4 @@
+= form_with url: products_search_path, method: :get, local: true, class: 'header-form' do |f|
+  = f.text_field :product_name, placeholder: 'キーワードから探す', type: 'search', class: 'input-default'
+  %button{type: 'submit', class: 'icon-search'}
+    %i.fas.fa-search

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -1,0 +1,8 @@
+.default-container
+  = render partial: "/partial/header"
+.search_result
+  .search_result__result 検索結果
+  .items-box-container.clearfix
+    .items-box-content.clearfix
+      - @products.each do |product|
+        = render partial: "/partial/product-box", locals: { product: product }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
     registrations: 'users/registrations',
     sessions: 'users/sessions'
   }
-#  get "users/new" => "users#new"
   get "registrations/new" => "registrations#new"
+  get "products/search" => "products#search"
 
   resources :users, only: [:show, :new, :create, :edit, :update]
   root 'products#index'

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -13,12 +13,13 @@ describe ProductsController do
        product = FactoryBot.create(:product)
        get :index, params: { product_status_id: product }
        expect(assigns(:product)).to match [product.product_status_id == 1]
+    end
 
-     it "該当するビューが描画されているか do
+    it "該当するビューが描画されているか" do
        get :index
        expect(response).to render_template :index
-     end
     end
+  end
 
   describe 'GET #new' do
     context 'ログイン中' do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 describe Product do
-  describe '#create' do
-    it "price が300円以上であること " do
+  describe "#create" do
+    it "price が300円以上であること" do
       product = build(:product, price: 300)
       expect(product).to be_valid
     end
@@ -75,6 +75,16 @@ describe Product do
       product = build(:product, category: nil)
       product.valid?
       expect(product.errors[:category]).to include("を入力してください")
+    end
+  end
+
+  describe "#self.search" do
+    it "Productsモデルあいまい検索" do
+      create(:product, name: "Awesome Ruby Book")
+      create(:product, name: "How to Ruby")
+      create(:product, name: "Rails")
+      products = Product.search("Ruby")
+      expect(products.size).to eq(2)
     end
   end
 end


### PR DESCRIPTION
# WHAT
商品名検索機能実装
 - Productsコントローラにsearchアクションを追加
 - 検索処理はProductsモデルに記載
 - あいまい検索
 - 検索キーワードは1つのみ
 - ヘッダ画面のSCSSを一部修正
 - ヘッダ画面のメルカリロゴをトップページへのリンクに変更
 - その他、RSpecソースコードのインデント調整やエラーになっていたend句追加を実施

# WHY
商品名検索機能実装のため

# DISPLAY
ローカルのデータが古いため、商品画像は表示されません
[![Image from Gyazo](https://i.gyazo.com/d23f0079616b60a500b34988800c1208.gif)](https://gyazo.com/d23f0079616b60a500b34988800c1208)