### PR TITLE
商品詳細のボタンの修正

### DIFF
--- a/app/assets/stylesheets/product-detail.scss
+++ b/app/assets/stylesheets/product-detail.scss
@@ -105,7 +105,8 @@
         font-size: 16px;
       }
     }
-    .product-buy-button {
+    @mixin product-button {
+      width: 100%;
       display: block;
       height: 56px;
       margin: 16px 0 0;
@@ -118,6 +119,13 @@
       -webkit-transition: all ease-out .3s;
       transition: all ease-out .3s;
     }
+    .product-buy-button{
+      @include product-button;
+    }
+    .product-delete-button {
+      @include product-button;
+    }
+
     .product-description {
       padding: 24px 0 0;
       line-height: 1.5;

--- a/app/assets/stylesheets/product-detail.scss
+++ b/app/assets/stylesheets/product-detail.scss
@@ -118,6 +118,8 @@
       font-size: 24px;
       -webkit-transition: all ease-out .3s;
       transition: all ease-out .3s;
+      cursor: pointer;
+      cursor: hand;
     }
     .product-buy-button{
       @include product-button;

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -63,10 +63,10 @@
       %span.product-price__tax (税込)
       %span.product-price__postage 送料込み
     .product-buy-button
-      = button_to "購入画面に進む", edit_purchase_path(@product), class: "product-buy-button"
+      = link_to "購入画面に進む", edit_purchase_path(@product), class: "btn product-buy-button"
     - if user_signed_in? && current_user.id == @product.purchase.seller_id
       .product-delete-button
-        = button_to 'この商品を削除する', product_path(@product), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "product-delete-button"
+        = link_to 'この商品を削除する', product_path(@product), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn product-delete-button"
     .product-description
       = @product.description
     .product-button-container.clearfix

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -63,10 +63,10 @@
       %span.product-price__tax (税込)
       %span.product-price__postage 送料込み
     .product-buy-button
-      = link_to "購入画面に進む", edit_purchase_path(@product)
+      = button_to "購入画面に進む", edit_purchase_path(@product), class: "product-buy-button"
     - if user_signed_in? && current_user.id == @product.purchase.seller_id
-      .product-buy-button
-        = link_to 'この商品を削除する', product_path(@product), method: :delete, data: { confirm: "本当に削除しますか？" }
+      .product-delete-button
+        = button_to 'この商品を削除する', product_path(@product), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "product-delete-button"
     .product-description
       = @product.description
     .product-button-container.clearfix


### PR DESCRIPTION
#WHY
ボタンがハイパーリンクになっていたため。
商品削除と購入が同じクラス名になっていたため。
#WHAT
link_toからbutton_toに変更
それぞれのクラス名の変更
@mixinを使い、CSSの再利用化