### PR TITLE
エラー修正

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,7 +11,7 @@ class Product < ApplicationRecord
   belongs_to :size, optional: true
   belongs_to :brand, optional: true
   belongs_to :product_status
-  has_one :purchase
+  has_one :purchase, dependent: :destroy
   delegate :seller, to: :purchase
   delegate :buyer, to: :purchase
   accepts_nested_attributes_for :purchase

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -70,7 +70,7 @@
         = link_to 'この商品を削除する', product_path(@product), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn product-delete-button"
     - else
       .product-buy-button
-      = link_to "購入画面に進む", edit_purchase_path(@product), class: "btn product-buy-button"
+        = link_to "購入画面に進む", edit_purchase_path(@product), class: "btn product-buy-button"
 
     .product-description
       = @product.description


### PR DESCRIPTION
# WHAT
product.rb のpurchaseのリレーションにdependent: :destroyを追加
詳細画面の購入ボタン修正

# WHY
update時エラー有のため
詳細画面の購入ボタンに崩れがあったため。
