### PR TITLE
商品出品ページ 調整

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,6 +5,11 @@ class Category < ApplicationRecord
   has_many :children, class_name: :Category, foreign_key: :parent_id
   belongs_to :size_type
 
+  def self.get_all_parents
+    # 全親カテゴリー（1階層目）を取得
+    @categories = Category.where(parent_id: nil)
+  end
+
   def self.get_all_children
     # 全子カテゴリー（2階層目）を取得
     category1 = Category.where(parent_id: nil)

--- a/app/views/products/_form_new.html.haml
+++ b/app/views/products/_form_new.html.haml
@@ -31,7 +31,7 @@
           %p.column_title
             カテゴリー
             %span.required 必須
-          = f.collection_select :category_id, Category.get_all_grandchildren, :id, :category ,include_blank: '---'
+          = f.collection_select :category_id, Category.get_all_parents, :id, :category ,include_blank: '---'
         .product_form__condition
           %p.column_title
             商品の状態

--- a/app/views/products/_form_new.html.haml
+++ b/app/views/products/_form_new.html.haml
@@ -10,7 +10,6 @@
     .product_form__image
       %p.column_title
         出品画像（最大10枚）
-        %span.required 必須
       = f.fields_for :images do |image|
         = image.file_field :image
     .product_form__main

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 describe Category do
   before do
-    category = FactoryBot.build(:category)
+    category = []
+    category << FactoryBot.build(:category)
+    category << FactoryBot.build(:category, category: "メンズ")
     categories = []
     categories << FactoryBot.build(:category, category: "トップス", parent_id: "1")
     categories << FactoryBot.build(:category, category: "ジャケット/アウター", parent_id: "1")
@@ -18,10 +20,16 @@ describe Category do
     progeny << FactoryBot.build(:category, category: "Tシャツ/カットソー", parent_id: "14")
     progeny << FactoryBot.build(:category, category: "ポロシャツ", parent_id: "14")
     progeny << FactoryBot.build(:category, category: "パーカー", parent_id: "14")
-    allow(Category).to receive(:get_all_children).and_return(category)
+    allow(Category).to receive(:get_all_parents).and_return(category)
+    allow(Category).to receive(:get_all_children).and_return(categories)
     allow(Category).to receive(:get_children).and_return(categories)
     allow(Category).to receive(:get_all_grandchildren).and_return(grandchildren)
     allow(Category).to receive(:get_progeny).and_return(progeny)
+  end
+  describe '#self.get_all_parents' do
+    it "finds all parents" do
+      category = Category.get_all_parents
+    end
   end
   describe '#self.get_all_children' do
     it "finds all children" do


### PR DESCRIPTION
# WHAT
商品出品ページ
### 商品画像の必須マークを削除
 - バリデーションは実装していないため問題なし
 - 画像なしでも出品できることを確認
### 表示カテゴリーを調整
 - 第1階層を選択できるよう変更
 - Categoryモデルにメソッドを1つ追加
 - RSpecもテスト済

# WHY
ユーザビリティ向上のため

# DISPLAY
[![Image from Gyazo](https://i.gyazo.com/ca1944a4471cdfb0ea72102c4dcbf05e.png)](https://gyazo.com/ca1944a4471cdfb0ea72102c4dcbf05e)
[![Image from Gyazo](https://i.gyazo.com/f7389d16a4d6d3cd37f7b509bb9d283f.png)](https://gyazo.com/f7389d16a4d6d3cd37f7b509bb9d283f)